### PR TITLE
Offer the aarch64 mac os JDK as arm64

### DIFF
--- a/index.json
+++ b/index.json
@@ -11,6 +11,11 @@
             "jdk@adoptium" : {
                 "17" : "tgz+https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17%2B35/OpenJDK17-jdk_aarch64_mac_hotspot_17_35.tar.gz"
             }
+        },
+        "arm64" : {
+            "jdk@adoptium" : {
+                "17" : "tgz+https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17%2B35/OpenJDK17-jdk_aarch64_mac_hotspot_17_35.tar.gz"
+            }
         }
     },
     "linux" : {

--- a/src/main/scala/org/typelevel/jdk/index/index.scala
+++ b/src/main/scala/org/typelevel/jdk/index/index.scala
@@ -33,6 +33,7 @@ val MainIndex: Index = Index(
     Release(MacOS, Amd64, Adoptium, Version("11"), TarGZ, url("https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jdk_x64_mac_hotspot_11.0.12_7.tar.gz")),
     Release(MacOS, Amd64, Adoptium, Version("8"), TarGZ, url("https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_x64_mac_hotspot_8u302b08.tar.gz")),
     Release(MacOS, Aarch64, Adoptium, Version("17"), TarGZ, url("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17%2B35/OpenJDK17-jdk_aarch64_mac_hotspot_17_35.tar.gz")),
+    Release(MacOS, Arm64, Adoptium, Version("17"), TarGZ, url("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17%2B35/OpenJDK17-jdk_aarch64_mac_hotspot_17_35.tar.gz")),
     Release(Windows, Amd64, Adoptium, Version("17"), Zip, url("https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17%2B35/OpenJDK17-jdk_x64_windows_hotspot_17_35.zip")),
     Release(Windows, Amd64, Adoptium, Version("11"), Zip, url("https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jdk_x64_windows_hotspot_11.0.12_7.zip")),
     Release(Windows, Amd64, Adoptium, Version("8"), Zip, url("https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08.1/OpenJDK8U-jdk_x64_windows_hotspot_8u302b08.zip")),

--- a/src/main/scala/org/typelevel/jdk/index/model/Arch.scala
+++ b/src/main/scala/org/typelevel/jdk/index/model/Arch.scala
@@ -19,3 +19,4 @@ package org.typelevel.jdk.index.model
 enum Arch(val jabbaName: String):
   case Amd64 extends Arch("amd64")
   case Aarch64 extends Arch("aarch64")
+  case Arm64 extends Arch("arm64")


### PR DESCRIPTION
Coursier is detecting the architecture of Apple Silicon as arm64 instead of aarch64, so offer the same release under that arch too.