### PR TITLE
Derive index url from context variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           distribution: ${{ matrix.distribution }}
           java-version: ${{ matrix.version }}
-          index: 'https://raw.githubusercontent.com/typelevel/jdk-index/${{ github.sha }}/index'
+          index: ${{ github.server_url }}/${{ github.repository }}/raw/${{ github.sha }}/index
 
       - name: Setup Java
         uses: actions/setup-java@v2


### PR DESCRIPTION
My fault for not mimicking the `JABBA_INDEX` in the first place.
https://github.com/typelevel/jdk-index/blob/d0b36dfa69134cb38bc608ccd6c717152248ad53/.github/workflows/ci.yml#L10